### PR TITLE
Use randombytes package for actually minimal size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var crypto = require('crypto');
+var randomBytes = require('randombytes');
 
 /**
  * id generator
@@ -22,7 +22,7 @@ function idgen(len, buf) {
 
   if (!Buffer.isBuffer(buf)) {
     var numBytes = Math.log(Math.pow(64, len)) / Math.log(2) / 8;
-    buf = crypto.randomBytes(numBytes);
+    buf = randomBytes(numBytes);
   }
 
   return buf.toString('base64')

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "url": "https://github.com/carlos8f/node-idgen.git"
   },
   "homepage": "https://github.com/carlos8f/node-idgen",
-  "dependencies": {},
+  "dependencies": {
+    "randombytes": "^2.0.3"
+  },
   "devDependencies": {
     "mocha": "*"
   },


### PR DESCRIPTION
![shrink ray](https://i.kinja-img.com/gawker-media/image/upload/s--rynOvS6f--/c_fit,fl_progressive,q_80,w_636/vaebztahnepukapuw53c.gif)

My team has been using `idgen` to do all sorts of collision-free id generation for a while now, but recently I added it to a frontend project and noticed it immediately added `1.5Mb` to the unminified package size, which seemed large for such a "minimal" library.

The culprit is the `crypto` package, which packagers like `browserify` and `webpack` polyfill with a **HUGE** but comprehensive [browser-compatible port](https://github.com/crypto-browserify/crypto-browserify).  This PR switches to using the [randombytes](https://www.npmjs.com/package/randombytes) package instead, to get just the amount of magic we need, without all the extra weight.  The end result is a **90% reduction** in compiled size.  Bundling `require('idgen')` with `browserify` before and after the change looks like this:

``` sh
# with require('crypto')
1483318 bytes written to dist/app.js (1.13 seconds)
# with require('randombytes')
154290 bytes written to dist/app.js (0.02 seconds)
```

Most of that `154kb` is the use of `Buffer` to build a `base64` string, so it could shrink even further without that, but 90% is still a huge win.  Also, `randombytes` falls back to the normal `crypto` module on the server, so that's a win-win.

Specs look like they still pass.  Let me know what you think!
